### PR TITLE
fix: reorder slot in TAlert

### DIFF
--- a/src/components/TAlert.vue
+++ b/src/components/TAlert.vue
@@ -25,19 +25,19 @@
         </slot>
       </component>
 
-      <button
+      <slot
         v-if="dismissible"
-        ref="close"
-        type="button"
-        :class="configuration.classesList?.close"
-        @click="doHide"
+        name="closeButton"
+        :show="doShow"
+        :hide="doHide"
+        :toggle="doToggle"
+        :configuration="configuration"
       >
-        <slot
-          name="closeButton"
-          :show="doShow"
-          :hide="doHide"
-          :toggle="doToggle"
-          :configuration="configuration"
+        <button
+          ref="close"
+          type="button"
+          :class="configuration.classesList?.close"
+          @click="doHide"
         >
           <custom-icon
             v-if="closeIcon"
@@ -49,8 +49,8 @@
             v-else
             ref="closeIcon"
           />
-        </slot>
-      </button>
+        </button>
+      </slot>
     </component>
   </transitionable>
 </template>


### PR DESCRIPTION
I think the order of the slot and the button should be inversed in case you don't want to use a button as a close control.