### PR TITLE
fix: add compatConfig

### DIFF
--- a/src/components/TAlert.vue
+++ b/src/components/TAlert.vue
@@ -66,9 +66,11 @@ import CloseIcon from '../icons/CloseIcon.vue';
 import Transitionable from './misc/Transitionable.vue';
 import useConfigurationWithClassesList from '../use/useConfigurationWithClassesList';
 import { getVariantPropsWithClassesList } from '../utils/getVariantProps';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TAlert',
   components: {
     CustomIcon,

--- a/src/components/TButton.vue
+++ b/src/components/TButton.vue
@@ -28,8 +28,10 @@ import { defineComponent, PropType } from 'vue';
 import { TButtonOptions, VueRouteAriaCurrentValue, VueRouteRouteLocationRaw } from '../types';
 import useConfiguration from '../use/useConfiguration';
 import { getVariantProps } from '../utils/getVariantProps';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TButton',
   props: {
     ...getVariantProps<TButtonOptions>(),

--- a/src/components/TCard.vue
+++ b/src/components/TCard.vue
@@ -48,9 +48,11 @@ import { defineComponent } from 'vue';
 import { TCardOptions } from '../types';
 import useConfigurationWithClassesList from '../use/useConfigurationWithClassesList';
 import { getVariantPropsWithClassesList } from '../utils/getVariantProps';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TCard',
   props: {
     ...getVariantPropsWithClassesList<TCardOptions, TCardClassesValidKeys>(),

--- a/src/components/TCheckbox.vue
+++ b/src/components/TCheckbox.vue
@@ -13,9 +13,11 @@ import { TCheckboxOptions, TCheckboxValue } from '../types';
 import { getVariantProps } from '../utils/getVariantProps';
 import useConfiguration from '../use/useConfiguration';
 import useVModel from '../use/useVModel';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TCheckbox',
   props: {
     ...getVariantProps<TCheckboxOptions>(),

--- a/src/components/TDialog.vue
+++ b/src/components/TDialog.vue
@@ -273,9 +273,11 @@ import CrossCircleIcon from '../icons/CrossCircleIcon.vue';
 import SolidCrossCircleIcon from '../icons/SolidCrossCircleIcon.vue';
 import LoadingIcon from '../icons/LoadingIcon.vue';
 import CloseIcon from '../icons/CloseIcon.vue';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TDialog',
   components: {
     TModal,

--- a/src/components/TDropdown.vue
+++ b/src/components/TDropdown.vue
@@ -78,6 +78,7 @@ import { TDropdownOptions } from '../types';
 import useConfigurationWithClassesList from '../use/useConfigurationWithClassesList';
 import { getVariantPropsWithClassesList } from '../utils/getVariantProps';
 import Transitionable from './misc/Transitionable.vue';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 export const validDropdownPlacements = [
   'auto',
@@ -99,6 +100,7 @@ export const validDropdownPlacements = [
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TDropdown',
   components: { Transitionable },
   inheritAttrs: false,

--- a/src/components/TInput.vue
+++ b/src/components/TInput.vue
@@ -17,8 +17,10 @@ import { TInputOptions, TInputValue } from '../types/components/t-input';
 import { getVariantProps } from '../utils/getVariantProps';
 import useVModel from '../use/useVModel';
 import useConfiguration from '../use/useConfiguration';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TInput',
   props: {
     ...getVariantProps<TInputOptions>(),

--- a/src/components/TModal.vue
+++ b/src/components/TModal.vue
@@ -105,9 +105,11 @@ import { getVariantPropsWithClassesList } from '../utils/getVariantProps';
 import CloseIcon from '../icons/CloseIcon.vue';
 import useVModel from '../use/useVModel';
 import Transitionable from './misc/Transitionable.vue';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TModal',
   components: {
     CloseIcon,

--- a/src/components/TRadio.vue
+++ b/src/components/TRadio.vue
@@ -13,9 +13,11 @@ import { TRadioOptions, TRadioValue } from '../types';
 import useConfiguration from '../use/useConfiguration';
 import useVModel from '../use/useVModel';
 import { getVariantProps } from '../utils/getVariantProps';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TRadio',
   props: {
     ...getVariantProps<TRadioOptions>(),

--- a/src/components/TRichSelect.vue
+++ b/src/components/TRichSelect.vue
@@ -172,9 +172,11 @@ import RichSelectClearButton from './TRichSelect/RichSelectClearButton.vue';
 import TDropdown, { validDropdownPlacements } from './TDropdown.vue';
 import TSelect from './TSelect.vue';
 import { sameWidthModifier } from '../utils/popper';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TRichSelect',
   components: {
     RichSelectTrigger,

--- a/src/components/TRichSelect/RichSelectClearButton.vue
+++ b/src/components/TRichSelect/RichSelectClearButton.vue
@@ -14,8 +14,10 @@
 import { defineComponent } from 'vue';
 import CloseIcon from '../../icons/CloseIcon.vue';
 import useInjectsClassesListClass from '../../use/useInjectsClassesListClass';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectClearButton',
   components: {
     CloseIcon,

--- a/src/components/TRichSelect/RichSelectDropdown.vue
+++ b/src/components/TRichSelect/RichSelectDropdown.vue
@@ -53,8 +53,10 @@ import RichSelectOptionsList from './RichSelectOptionsList.vue';
 import RichSelectSearchInput from './RichSelectSearchInput.vue';
 import RichSelectState from './RichSelectState.vue';
 import useInjectsClassesListClass from '../../use/useInjectsClassesListClass';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectDropdown',
   components: {
     RichSelectOptionsList,

--- a/src/components/TRichSelect/RichSelectOption.vue
+++ b/src/components/TRichSelect/RichSelectOption.vue
@@ -82,8 +82,10 @@ import {
 import { CSSClass, NormalizedOption, normalizedOptionIsDisabled } from '@variantjs/core';
 import useInjectsClassesList from '../../use/useInjectsClassesList';
 import CheckmarkIcon from '../../icons/CheckmarkIcon.vue';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectOption',
   components: {
     CheckmarkIcon,

--- a/src/components/TRichSelect/RichSelectOptionsList.vue
+++ b/src/components/TRichSelect/RichSelectOptionsList.vue
@@ -50,8 +50,10 @@ import { debounce, NormalizedOptions, normalizeMeasure } from '@variantjs/core';
 import RichSelectOption from './RichSelectOption.vue';
 import { TRichSelectOptions } from '../../types';
 import useInjectsClassesList from '../../use/useInjectsClassesList';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectOptionsList',
   components: {
     RichSelectOption,

--- a/src/components/TRichSelect/RichSelectSearchInput.vue
+++ b/src/components/TRichSelect/RichSelectSearchInput.vue
@@ -21,8 +21,10 @@ import {
 import { TRichSelectOptions } from '../../types/components/t-rich-select';
 import useInjectsClassesList from '../../use/useInjectsClassesList';
 import useInjectsConfiguration from '../../use/useInjectsConfiguration';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectSearchInput',
   setup() {
     const search = ref<HTMLInputElement>();

--- a/src/components/TRichSelect/RichSelectState.vue
+++ b/src/components/TRichSelect/RichSelectState.vue
@@ -31,8 +31,10 @@ import {
 import { TRichSelectOptions } from '../../types/components/t-rich-select';
 import useInjectsClassesList from '../../use/useInjectsClassesList';
 import useInjectsConfiguration from '../../use/useInjectsConfiguration';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectState',
   setup() {
     const options = inject<ComputedRef<TRichSelectOptions>>('options')!;

--- a/src/components/TRichSelect/RichSelectTrigger.vue
+++ b/src/components/TRichSelect/RichSelectTrigger.vue
@@ -76,8 +76,10 @@ import LoadingIcon from '../../icons/LoadingIcon.vue';
 import { TRichSelectOptions } from '../../types/components/t-rich-select';
 import useInjectsClassesList from '../../use/useInjectsClassesList';
 import useInjectsConfiguration from '../../use/useInjectsConfiguration';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectTrigger',
   components: {
     RichSelectTriggerTags,

--- a/src/components/TRichSelect/RichSelectTriggerTags.vue
+++ b/src/components/TRichSelect/RichSelectTriggerTags.vue
@@ -28,8 +28,10 @@ import { NormalizedOption } from '@variantjs/core';
 import { ComputedRef, defineComponent, inject } from 'vue';
 import RichSelectTriggerTagsTag from './RichSelectTriggerTagsTag.vue';
 import useInjectsClassesListClass from '../../use/useInjectsClassesListClass';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectTriggerTags',
   components: {
     RichSelectTriggerTagsTag,

--- a/src/components/TRichSelect/RichSelectTriggerTagsTag.vue
+++ b/src/components/TRichSelect/RichSelectTriggerTagsTag.vue
@@ -48,8 +48,10 @@ import { NormalizedOption, normalizedOptionIsDisabled } from '@variantjs/core';
 import { defineComponent, inject, PropType } from 'vue';
 import CloseIcon from '../../icons/CloseIcon.vue';
 import useInjectsClassesList from '../../use/useInjectsClassesList';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'RichSelectTriggerTagsTag',
   components: {
     CloseIcon,

--- a/src/components/TSelect.vue
+++ b/src/components/TSelect.vue
@@ -23,9 +23,11 @@ import useMulipleableVModel from '../use/useMulipleableVModel';
 import useMultioptions from '../use/useMultioptions';
 import useConfiguration from '../use/useConfiguration';
 import { getVariantProps } from '../utils/getVariantProps';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TSelect',
   components: {
     TSelectOption,

--- a/src/components/TSelect/TSelectOption.vue
+++ b/src/components/TSelect/TSelectOption.vue
@@ -22,9 +22,11 @@
 <script lang="ts">
 import { NormalizedOption } from '@variantjs/core';
 import { defineComponent, PropType } from 'vue';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TSelectOption',
   props: {
     option: {

--- a/src/components/TTag.vue
+++ b/src/components/TTag.vue
@@ -15,9 +15,11 @@ import { defineComponent } from 'vue';
 import { TTagOptions } from '../types';
 import useConfiguration from '../use/useConfiguration';
 import { getVariantProps } from '../utils/getVariantProps';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TTag',
   props: {
     ...getVariantProps<TTagOptions>(),

--- a/src/components/TTextarea.vue
+++ b/src/components/TTextarea.vue
@@ -17,8 +17,10 @@ import { TTextareaOptions, TTextareaValue } from '../types';
 import { getVariantProps } from '../utils/getVariantProps';
 import useVModel from '../use/useVModel';
 import useConfiguration from '../use/useConfiguration';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TTextarea',
   props: {
     ...getVariantProps<TTextareaOptions>(),

--- a/src/components/TToggle.vue
+++ b/src/components/TToggle.vue
@@ -63,9 +63,11 @@ import {
 import useConfigurationWithClassesList from '../use/useConfigurationWithClassesList';
 import { getVariantPropsWithClassesList } from '../utils/getVariantProps';
 import { TToggleOptions, TToggleValue } from '../types/components/t-toggle';
+import { getGlobalComponentOptions } from '../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TToggle',
   props: {
     ...getVariantPropsWithClassesList<TToggleOptions, TToggleClassesValidKeys>(),

--- a/src/components/misc/TextPlaceholder.vue
+++ b/src/components/misc/TextPlaceholder.vue
@@ -10,8 +10,10 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import useInjectsClassesListClass from '../../use/useInjectsClassesListClass';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'TextPlaceholder',
   props: {
     classProperty: {

--- a/src/components/misc/Transitionable.vue
+++ b/src/components/misc/Transitionable.vue
@@ -14,9 +14,11 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { getGlobalComponentOptions } from '../../utils/getGlobalComponentOptions';
 
 // @vue/component
 export default defineComponent({
+  ...getGlobalComponentOptions(),
   name: 'Transitionable',
   props: {
     classesList: {

--- a/src/utils/getGlobalComponentOptions.ts
+++ b/src/utils/getGlobalComponentOptions.ts
@@ -1,0 +1,7 @@
+export const getGlobalComponentOptions = () => {
+  return {
+    compatConfig: {
+      MODE: 3,
+    },
+  };
+}


### PR DESCRIPTION
This PR will add a `compatConfig` to every component so `@vue/compat` knows that it deals with `vue@3` components (see https://v3.vuejs.org/guide/migration/migration-build.html#per-component-config)

This ~~potentially~~ solves:
https://github.com/variantjs/vue/issues/11