### PR TITLE
fix: provide src files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.8",
   "description": "Vue VariantJS: Fully configurable Vue 3 components styled with TailwindCSS",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/**/*"
   ],
   "types": "./dist/index.d.ts",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
In order to debug the library it would be great if you could provide the src files as well. Otherwise the devtools will not find the source code that are referenced in the source maps.