### PR TITLE
feat: export LoadingIcon

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ import TTag from './components/TTag.vue';
 import TToggle from './components/TToggle.vue';
 import TModal from './components/TModal.vue';
 
+// Import icons
+import LoadingIcon from './icons/LoadingIcon.vue';
+
 // Import uses
 import useActivableOption from './use/useActivableOption';
 import useConfiguration from './use/useConfiguration';
@@ -65,7 +68,12 @@ export {
   plugin as variantJS,
 };
 
-// // Export utils
+// Export icons
+export {
+  LoadingIcon,
+};
+
+// Export utils
 export {
   Emitter,
   getVariantProps,


### PR DESCRIPTION
It would be nice to export the `LoadingIcon` so I can use it in other parts of my app as well to keep it consistent.