### PR TITLE
test: fix test after merge

### DIFF
--- a/src/__tests/index.spec.ts
+++ b/src/__tests/index.spec.ts
@@ -18,6 +18,7 @@ describe('main file', () => {
       'TModal',
       'TToggle',
       'variantJS',
+      'LoadingIcon',
       'Emitter',
       'getVariantProps',
       'getVariantPropsWithClassesList',


### PR DESCRIPTION
This PR fixes the tests for the exports which failed since the merge of https://github.com/variantjs/vue/pull/32.

@alfonsobries sorry, your tests are too good and I am used to push small fixes like these via the Github directly. Will use the local project in the future 😊 